### PR TITLE
Changes to the LRURLRequestOperation

### DIFF
--- a/Classes/LRURLRequestOperation.m
+++ b/Classes/LRURLRequestOperation.m
@@ -43,8 +43,11 @@
   [super dealloc];
 }
 
-- (void)start
-{
+- (void)start {
+  if (![NSThread isMainThread]) {
+    [self performSelectorOnMainThread:@selector(start) withObject:nil waitUntilDone:NO];
+    return;
+  }
   NSAssert(URLRequest, @"Cannot start URLRequestOperation without a NSURLRequest.");
   
   [self setExecuting:YES];
@@ -55,12 +58,9 @@
     [self setFinished:YES]; 
   }
   
-  [URLConnection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+  // Common modes instead of default so it won't stall uiscrollview scrolling
+  [URLConnection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
   [URLConnection start];
-  
-  do {
-    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
-  } while (!_isFinished);
 }
 
 - (void)finish;


### PR DESCRIPTION
I changed the way LRURLRequestOperation behaves as a concurrent operation. First of all let me say I really like LRResty. It's much like the frameworks I usually build internally in my apps to do networking. I switched to Resty because it's much more reusable and contains more features. However after switching I ran into several issues that I had solved in my code already. This pull-request will address a few of them.
1. As of iOS 4.0 the start method of a NSOperation is not automatically called not the main thread. This results in a NSURLConnection being created on a different thread than the main one. NSURLConnection in async mode used to require the main thread. This has been improved, but can't find word from Apple this has been fixed entirely. Thus start makes sure it is called on the main thread. 
   This also makes sure all the async call backs are on the main thread. For example this crashes an application:

``` Objective-C
[[LRResty client] get:someurl withBlock:^(LRRestyResponse *) {
    // update the UI
}];
```

By making sure the NSURLConnection is being executed on the main thread, callbacks will be handles on the main thread, so it makes it save to actually update the UI in a response.
1. Use the NSRunLoopCommonModes instead of the default one. When scrolling a UIScrollView the defaultrunloop is blocked. So say you want to lazy load images for tableviewcells the NSURLConnection won't fire before the scrollview stopped scrolling. By changing this to the common modes loading of images and updating the cells will actually happen _while_ scrolling a table view.
2. No need for a loop polling the runloop here. The NSOperation won't be destroyed unless isFinished is set to YES.
