### PR TITLE
added support for payload in DELETE requests

### DIFF
--- a/Classes/LRRestyClient+DELETE.h
+++ b/Classes/LRRestyClient+DELETE.h
@@ -57,6 +57,16 @@
  */
 - (LRRestyRequest *)delete:(NSString *)urlString headers:(NSDictionary *)headers withBlock:(LRRestyResponseBlock)block;
 
+/**
+ Performs a DELETE request on URL resource with block response handling.
+ @param urlString   The URL resource to delete.
+ @param payload     The HTTP request body
+ @param headers     A dictionary of HTTP request headers.
+ @param block       The response handler.
+ @returns The request object.
+ */
+- (LRRestyRequest *)delete:(NSString *)urlString payload:(id)payload headers:(NSDictionary *)headers withBlock:(LRRestyResponseBlock)block;
+
 #pragma mark -
 #pragma mark Synchronous API
 

--- a/Classes/LRRestyClient+DELETE.m
+++ b/Classes/LRRestyClient+DELETE.m
@@ -24,7 +24,7 @@
 
 - (LRRestyRequest *)delete:(NSString *)urlString headers:(NSDictionary *)headers delegate:(id<LRRestyClientResponseDelegate>)delegate;
 {
-  return [HTTPClient DELETE:[NSURL URLWithString:urlString] headers:headers delegate:[LRRestyClientProxyDelegate proxyForClient:self responseDelegate:delegate]];
+  return [HTTPClient DELETE:[NSURL URLWithString:urlString] payload:nil headers:headers delegate:[LRRestyClientProxyDelegate proxyForClient:self responseDelegate:delegate]];
 }
 
 #pragma mark -
@@ -37,7 +37,12 @@
 
 - (LRRestyRequest *)delete:(NSString *)urlString headers:(NSDictionary *)headers withBlock:(LRRestyResponseBlock)block;
 {
-  return [HTTPClient DELETE:[NSURL URLWithString:urlString] headers:headers delegate:[LRRestyClientBlockDelegate delegateWithBlock:block]];
+    return [HTTPClient DELETE:[NSURL URLWithString:urlString] payload:nil headers:headers delegate:[LRRestyClientBlockDelegate delegateWithBlock:block]];
+}
+
+- (LRRestyRequest *)delete:(NSString *)urlString payload:(id)payload headers:(NSDictionary *)headers withBlock:(LRRestyResponseBlock)block 
+{
+    return [HTTPClient DELETE:[NSURL URLWithString:urlString] payload:payload headers:headers delegate:[LRRestyClientBlockDelegate delegateWithBlock:block]];    
 }
 
 #pragma mark -

--- a/Classes/LRRestyHTTPClient.h
+++ b/Classes/LRRestyHTTPClient.h
@@ -18,7 +18,7 @@
 - (LRRestyRequest *)GET:(NSURL *)url parameters:(NSDictionary *)parameters headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
 - (LRRestyRequest *)POST:(NSURL *)url payload:(id)payload headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
 - (LRRestyRequest *)PUT:(NSURL *)url payload:(id)payload headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
-- (LRRestyRequest *)DELETE:(NSURL *)url headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
+- (LRRestyRequest *)DELETE:(NSURL *)url payload:(id)payload headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
 - (LRRestyRequest *)performRequest:(LRRestyRequest *)request;
 - (void)cancelAllRequests;
 @end

--- a/Classes/LRRestyHTTPClient.m
+++ b/Classes/LRRestyHTTPClient.m
@@ -62,9 +62,9 @@
   return [self performRequest:[self requestForURL:url method:@"PUT" payload:payload headers:headers requestDelegate:requestDelegate]];
 }
 
-- (LRRestyRequest *)DELETE:(NSURL *)url headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
+- (LRRestyRequest *)DELETE:(NSURL *)url payload:(id)payload headers:(NSDictionary *)headers delegate:(id<LRRestyRequestDelegate>)requestDelegate;
 {
-    return [self performRequest:[self requestForURL:url method:@"DELETE" payload:nil headers:headers requestDelegate:requestDelegate]];
+    return [self performRequest:[self requestForURL:url method:@"DELETE" payload:payload headers:headers requestDelegate:requestDelegate]];
 }
 
 - (LRRestyRequest *)performRequest:(LRRestyRequest *)request;

--- a/Tests/Acceptance/DeleteResourceTests.m
+++ b/Tests/Acceptance/DeleteResourceTests.m
@@ -39,6 +39,23 @@ RESTY_CLIENT_ACCEPTANCE_TEST(DeleteResourceTests)
   assertEventuallyThat(&lastResponse, is(responseWithRequestEcho(@"env.HTTP_X_TEST_HEADER", @"Resty")));
 }
 
+- (void)testCanPerformDeleteRequestWithHTTPBody
+{
+  __block LRRestyResponse *testLocalResponse = nil;
+  NSString *payload = @"{\"foo\":\"bar\"}";
+  mimicDELETE(@"/simple/resource", andEchoRequest(), ^{  
+    [client delete:resourceWithPath(@"/simple/resource") 
+           payload:payload
+           headers:[NSDictionary dictionaryWithObject:@"Resty" forKey:@"X-Test-Header"]
+         withBlock:^(LRRestyResponse *response) {
+             testLocalResponse = [response retain];
+         }];
+  });
+
+  assertEventuallyThat(&lastResponse, is(responseWithRequestEcho(@"body", payload)));
+  [testLocalResponse release];
+}
+
 - (void)testCanModifyRequestsBeforeTheyAreSentUsingBlock
 {
   mimicDELETE(@"/simple/resource", andEchoRequest(), ^{  


### PR DESCRIPTION
I know that there's some contention about whether DELETE requests should support an HTTP body, but it's not forbidden in the spec, and you're often at the mercy of what the API developer defines, which is the case we ran into recently. Since it's contentious, I added one new method that includes a payload, rather than adding payload to all the existing methods. But I'd be happy to refactor the delete methods to all include a payload if you think that would be cleaner.
