### PR TITLE
Updated build settings for 5.0 SDK and armv6

### DIFF
--- a/LRResty.xcodeproj/project.pbxproj
+++ b/LRResty.xcodeproj/project.pbxproj
@@ -1444,7 +1444,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/LRResty.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1466,7 +1469,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				DSTROOT = /tmp/LRResty.dst;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ namespace :build do
   CONFIG = "Release"
   LIB_NAME = "libLRResty.a"
   BUILD_DIR = "build"
-  BASE_SDK = 4.3
+  BASE_SDK = 5.0
   PACKAGE_SUFFIX = ENV["PACKAGE_SUFFIX"] || RESTY_VERSION
   
   desc "Build the static library for the simulator platform"


### PR DESCRIPTION
I couldn't build LRResty because Xcode 4.3 doesn't include a 4.3 SDK, and we needed it to support armv6 for a project we're using it in.
