### PR TITLE
LRRestyResource post:callback method fix

### DIFF
--- a/Classes/LRRestyResource.h
+++ b/Classes/LRRestyResource.h
@@ -32,6 +32,7 @@ typedef void (^LRRestyResourceResponseBlock)(LRRestyResponse *response, LRRestyR
 - (LRRestyRequest *)get:(LRRestyResourceResponseBlock)responseBlock;
 - (void)post:(LRRestyResourceResponseBlock)responseBlock;
 - (void)post:(id)payload callback:(LRRestyResourceResponseBlock)responseBlock;
+-(void)put:(id)payload callback:(LRRestyResourceResponseBlock)responseBlock;
 @end
 
 @interface LRRestyResource (Streaming)

--- a/Classes/LRRestyResource.m
+++ b/Classes/LRRestyResource.m
@@ -133,10 +133,19 @@
 - (void)post:(id)payload callback:(LRRestyResourceResponseBlock)responseBlock;
 {
   __block LRRestyResource *blockResource = [self retain];
-  [restClient put:[URL absoluteString] payload:payload headers:nil withBlock:^(LRRestyResponse *response){
+  [restClient post:[URL absoluteString] payload:payload headers:nil withBlock:^(LRRestyResponse *response){
     responseBlock(response, blockResource);
     [blockResource release];
   }];
+}
+
+- (void)put:(id)payload callback:(LRRestyResourceResponseBlock)responseBlock;
+{
+    __block LRRestyResource *blockResource = [self retain];
+    [restClient put:[URL absoluteString] payload:payload headers:nil withBlock:^(LRRestyResponse *response){
+        responseBlock(response, blockResource);
+        [blockResource release];
+    }];
 }
 
 // forward other methods to the client


### PR DESCRIPTION
LRRestyResource post:callback method issued PUT requests instead of POST.
I've fixed it to use POST and created a new put:callback method that can issue PUT requests to the server.
